### PR TITLE
Integrate Ent with GraphQL codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ gql-generate:
 	go run github.com/99designs/gqlgen generate
 
 generate:
-	make gql-generate
+	make ent-generate
 
 docker-container:
 	docker compose -f ./docker/docker-compose.yml up

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ gql-generate:
 	go run github.com/99designs/gqlgen generate
 
 generate:
-	make ent-generate
+	make ent-generate && make gql-generate
 
 docker-container:
 	docker compose -f ./docker/docker-compose.yml up

--- a/ent/entc.go
+++ b/ent/entc.go
@@ -1,0 +1,25 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"log"
+
+	"entgo.io/contrib/entgql"
+	"entgo.io/ent/entc"
+	"entgo.io/ent/entc/gen"
+)
+
+func main() {
+    ex, err := entgql.NewExtension(
+        entgql.WithSchemaGenerator(),
+        entgql.WithSchemaPath("../graph/schema.graphqls"),
+    )
+    if err != nil {
+        log.Fatalf("creating entgql extension: %v", err)
+    }
+    if err := entc.Generate("./schema", &gen.Config{}, entc.Extensions(ex)); err != nil {
+        log.Fatalf("running ent codegen: %v", err)
+    }
+}

--- a/ent/generate.go
+++ b/ent/generate.go
@@ -1,4 +1,3 @@
 package ent
 
-// The generate command should not be used since the main function handles this before starting the server
-//go:generate go run -mod=mod entgo.io/ent/cmd/ent generate ./schema
+//go:generate go run -mod=mod entc.go

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -2,6 +2,81 @@
 
 package model
 
-type Me struct {
-	Name string `json:"name"`
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"time"
+)
+
+// Information about pagination in a connection.
+// https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
+type PageInfo struct {
+	// When paginating forwards, are there more items?
+	HasNextPage bool `json:"hasNextPage"`
+	// When paginating backwards, are there more items?
+	HasPreviousPage bool `json:"hasPreviousPage"`
+	// When paginating backwards, the cursor to continue.
+	StartCursor *string `json:"startCursor"`
+	// When paginating forwards, the cursor to continue.
+	EndCursor *string `json:"endCursor"`
+}
+
+type User struct {
+	ID          string     `json:"id"`
+	Email       string     `json:"email"`
+	PhoneNumber *string    `json:"phoneNumber"`
+	Name        string     `json:"name"`
+	Avatar      *string    `json:"avatar"`
+	BirthDate   *time.Time `json:"birthDate"`
+	Bio         *string    `json:"bio"`
+	Active      bool       `json:"active"`
+	CreatedAt   time.Time  `json:"createdAt"`
+	UpdatedAt   time.Time  `json:"updatedAt"`
+}
+
+func (User) IsNode() {}
+
+// Possible directions in which to order a list of items when provided an `orderBy` argument.
+type OrderDirection string
+
+const (
+	// Specifies an ascending order for a given `orderBy` argument.
+	OrderDirectionAsc OrderDirection = "ASC"
+	// Specifies a descending order for a given `orderBy` argument.
+	OrderDirectionDesc OrderDirection = "DESC"
+)
+
+var AllOrderDirection = []OrderDirection{
+	OrderDirectionAsc,
+	OrderDirectionDesc,
+}
+
+func (e OrderDirection) IsValid() bool {
+	switch e {
+	case OrderDirectionAsc, OrderDirectionDesc:
+		return true
+	}
+	return false
+}
+
+func (e OrderDirection) String() string {
+	return string(e)
+}
+
+func (e *OrderDirection) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = OrderDirection(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid OrderDirection", str)
+	}
+	return nil
+}
+
+func (e OrderDirection) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -1,11 +1,62 @@
-# GraphQL schema example
-#
-# https://gqlgen.com/getting-started/
-
-type Me {
-  name: String!
+directive @goField(forceResolver: Boolean, name: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @goModel(model: String, models: [String!]) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
+"""
+Define a Relay Cursor type:
+https://relay.dev/graphql/connections.htm#sec-Cursor
+"""
+scalar Cursor
+"""
+An object with an ID.
+Follows the [Relay Global Object Identification Specification](https://relay.dev/graphql/objectidentification.htm)
+"""
+interface Node @goModel(model: "github.com/m3-app/backend/ent.Noder") {
+  """The id of the object."""
+  id: ID!
 }
-
+"""Possible directions in which to order a list of items when provided an `orderBy` argument."""
+enum OrderDirection {
+  """Specifies an ascending order for a given `orderBy` argument."""
+  ASC
+  """Specifies a descending order for a given `orderBy` argument."""
+  DESC
+}
+"""
+Information about pagination in a connection.
+https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
+"""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+}
 type Query {
-  me(name: String!): Me!
+  """Fetches an object given its ID."""
+  node(
+    """ID of the object."""
+    id: ID!
+  ): Node
+  """Lookup nodes by a list of IDs."""
+  nodes(
+    """The list of node IDs."""
+    ids: [ID!]!
+  ): [Node]!
+}
+"""The builtin Time type"""
+scalar Time
+type User implements Node {
+  id: ID!
+  email: String!
+  phoneNumber: String
+  name: String!
+  avatar: String
+  birthDate: Time
+  bio: String
+  active: Boolean!
+  createdAt: Time!
+  updatedAt: Time!
 }

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -6,15 +6,19 @@ package graph
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/m3-app/backend/graph/model"
+	"github.com/m3-app/backend/ent"
 )
 
-// Me is the resolver for the me field.
-func (r *queryResolver) Me(ctx context.Context, name string) (*model.Me, error) {
-	return &model.Me{
-		Name: name,
-	}, nil
+// Node is the resolver for the node field.
+func (r *queryResolver) Node(ctx context.Context, id string) (ent.Noder, error) {
+	panic(fmt.Errorf("not implemented: Node - node"))
+}
+
+// Nodes is the resolver for the nodes field.
+func (r *queryResolver) Nodes(ctx context.Context, ids []string) ([]ent.Noder, error) {
+	panic(fmt.Errorf("not implemented: Nodes - nodes"))
 }
 
 // Query returns QueryResolver implementation.

--- a/server.go
+++ b/server.go
@@ -6,9 +6,6 @@ import (
 	"net/http"
 	"os"
 
-	"entgo.io/contrib/entgql"
-	"entgo.io/ent/entc"
-	"entgo.io/ent/entc/gen"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/go-chi/chi/v5"
@@ -22,9 +19,6 @@ import (
 const defaultPort = "8080"
 
 func main() {
-	// GraphQL integration https://entgo.io/docs/graphql#quick-introduction
-	entc_generate()
-
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = defaultPort
@@ -69,14 +63,4 @@ func main() {
 	if err := http.ListenAndServe(port_str, router); err != nil {
 		log.Fatal(err)
 	}
-}
-
-func entc_generate() {
-	ex, err := entgql.NewExtension()
-    if err != nil {
-        log.Fatalf("creating entgql extension: %v", err)
-    }
-    if err := entc.Generate("./ent/schema", &gen.Config{}, entc.Extensions(ex)); err != nil {
-        log.Fatalf("running ent codegen: %v", err)
-    }
 }

--- a/services/service.go
+++ b/services/service.go
@@ -13,30 +13,15 @@ type ServiceConfig struct {
 	Validator *validator.Validate
 }
 
-type ServiceBase struct {
-	ServiceConfig
-	Table string
-}
-
 type Service struct {
-	ServiceConfig
 	UserService UserService
 	// list of services UserService UserService
 }
 
-func CreateService(config ServiceConfig, table string) ServiceBase {
-	return ServiceBase{
-		ServiceConfig: config,
-		Table: table,
-	}
-}
-
 func New(config ServiceConfig) Service {
-	service := Service{
-		ServiceConfig: config,
-	}
+	service := Service{}
 	service.UserService = UserService{
-		ServiceBase: CreateService(config, "users"),
+		ServiceConfig: config,
 	}
 	return service
 }

--- a/services/user_service.go
+++ b/services/user_service.go
@@ -1,5 +1,5 @@
 package services
 
 type UserService struct {
-	ServiceBase
+	ServiceConfig
 }


### PR DESCRIPTION
Adds proper integration with Ent and GraphQL packages. This will also ensure that all models/schemas created using Ent will also generate valid GraphQL types, queries, and mutations.