### PR TITLE
Auth platform column in `auth_state` table

### DIFF
--- a/database/jet/postgres/public/model/auth_state.go
+++ b/database/jet/postgres/public/model/auth_state.go
@@ -16,4 +16,5 @@ type AuthState struct {
 	LoggedInAt time.Time
 	UserID     int64
 	IPAddress  *string
+	Platform   UserAuthPlatformType
 }

--- a/database/jet/postgres/public/model/user.go
+++ b/database/jet/postgres/public/model/user.go
@@ -12,16 +12,15 @@ import (
 )
 
 type User struct {
-	ID           int64 `sql:"primary_key"`
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
-	Email        string
-	PhoneNumber  *string
-	Name         string
-	Password     *string
-	Avatar       *string
-	BirthDate    *time.Time
-	Bio          *string
-	Active       bool
-	AuthPlatform UserAuthPlatformType
+	ID          int64 `sql:"primary_key"`
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	Email       string
+	PhoneNumber *string
+	Name        string
+	Password    *string
+	Avatar      *string
+	BirthDate   *time.Time
+	Bio         *string
+	Active      bool
 }

--- a/database/jet/postgres/public/table/auth_state.go
+++ b/database/jet/postgres/public/table/auth_state.go
@@ -21,6 +21,7 @@ type authStateTable struct {
 	LoggedInAt postgres.ColumnTimestampz
 	UserID     postgres.ColumnInteger
 	IPAddress  postgres.ColumnString
+	Platform   postgres.ColumnString
 
 	AllColumns     postgres.ColumnList
 	MutableColumns postgres.ColumnList
@@ -65,8 +66,9 @@ func newAuthStateTableImpl(schemaName, tableName, alias string) authStateTable {
 		LoggedInAtColumn = postgres.TimestampzColumn("logged_in_at")
 		UserIDColumn     = postgres.IntegerColumn("user_id")
 		IPAddressColumn  = postgres.StringColumn("ip_address")
-		allColumns       = postgres.ColumnList{IDColumn, LoggedInAtColumn, UserIDColumn, IPAddressColumn}
-		mutableColumns   = postgres.ColumnList{LoggedInAtColumn, UserIDColumn, IPAddressColumn}
+		PlatformColumn   = postgres.StringColumn("platform")
+		allColumns       = postgres.ColumnList{IDColumn, LoggedInAtColumn, UserIDColumn, IPAddressColumn, PlatformColumn}
+		mutableColumns   = postgres.ColumnList{LoggedInAtColumn, UserIDColumn, IPAddressColumn, PlatformColumn}
 	)
 
 	return authStateTable{
@@ -77,6 +79,7 @@ func newAuthStateTableImpl(schemaName, tableName, alias string) authStateTable {
 		LoggedInAt: LoggedInAtColumn,
 		UserID:     UserIDColumn,
 		IPAddress:  IPAddressColumn,
+		Platform:   PlatformColumn,
 
 		AllColumns:     allColumns,
 		MutableColumns: mutableColumns,

--- a/database/jet/postgres/public/table/user.go
+++ b/database/jet/postgres/public/table/user.go
@@ -17,18 +17,17 @@ type userTable struct {
 	postgres.Table
 
 	// Columns
-	ID           postgres.ColumnInteger
-	CreatedAt    postgres.ColumnTimestampz
-	UpdatedAt    postgres.ColumnTimestampz
-	Email        postgres.ColumnString
-	PhoneNumber  postgres.ColumnString
-	Name         postgres.ColumnString
-	Password     postgres.ColumnString
-	Avatar       postgres.ColumnString
-	BirthDate    postgres.ColumnDate
-	Bio          postgres.ColumnString
-	Active       postgres.ColumnBool
-	AuthPlatform postgres.ColumnString
+	ID          postgres.ColumnInteger
+	CreatedAt   postgres.ColumnTimestampz
+	UpdatedAt   postgres.ColumnTimestampz
+	Email       postgres.ColumnString
+	PhoneNumber postgres.ColumnString
+	Name        postgres.ColumnString
+	Password    postgres.ColumnString
+	Avatar      postgres.ColumnString
+	BirthDate   postgres.ColumnDate
+	Bio         postgres.ColumnString
+	Active      postgres.ColumnBool
 
 	AllColumns     postgres.ColumnList
 	MutableColumns postgres.ColumnList
@@ -69,38 +68,36 @@ func newUserTable(schemaName, tableName, alias string) *UserTable {
 
 func newUserTableImpl(schemaName, tableName, alias string) userTable {
 	var (
-		IDColumn           = postgres.IntegerColumn("id")
-		CreatedAtColumn    = postgres.TimestampzColumn("created_at")
-		UpdatedAtColumn    = postgres.TimestampzColumn("updated_at")
-		EmailColumn        = postgres.StringColumn("email")
-		PhoneNumberColumn  = postgres.StringColumn("phone_number")
-		NameColumn         = postgres.StringColumn("name")
-		PasswordColumn     = postgres.StringColumn("password")
-		AvatarColumn       = postgres.StringColumn("avatar")
-		BirthDateColumn    = postgres.DateColumn("birth_date")
-		BioColumn          = postgres.StringColumn("bio")
-		ActiveColumn       = postgres.BoolColumn("active")
-		AuthPlatformColumn = postgres.StringColumn("auth_platform")
-		allColumns         = postgres.ColumnList{IDColumn, CreatedAtColumn, UpdatedAtColumn, EmailColumn, PhoneNumberColumn, NameColumn, PasswordColumn, AvatarColumn, BirthDateColumn, BioColumn, ActiveColumn, AuthPlatformColumn}
-		mutableColumns     = postgres.ColumnList{CreatedAtColumn, UpdatedAtColumn, EmailColumn, PhoneNumberColumn, NameColumn, PasswordColumn, AvatarColumn, BirthDateColumn, BioColumn, ActiveColumn, AuthPlatformColumn}
+		IDColumn          = postgres.IntegerColumn("id")
+		CreatedAtColumn   = postgres.TimestampzColumn("created_at")
+		UpdatedAtColumn   = postgres.TimestampzColumn("updated_at")
+		EmailColumn       = postgres.StringColumn("email")
+		PhoneNumberColumn = postgres.StringColumn("phone_number")
+		NameColumn        = postgres.StringColumn("name")
+		PasswordColumn    = postgres.StringColumn("password")
+		AvatarColumn      = postgres.StringColumn("avatar")
+		BirthDateColumn   = postgres.DateColumn("birth_date")
+		BioColumn         = postgres.StringColumn("bio")
+		ActiveColumn      = postgres.BoolColumn("active")
+		allColumns        = postgres.ColumnList{IDColumn, CreatedAtColumn, UpdatedAtColumn, EmailColumn, PhoneNumberColumn, NameColumn, PasswordColumn, AvatarColumn, BirthDateColumn, BioColumn, ActiveColumn}
+		mutableColumns    = postgres.ColumnList{CreatedAtColumn, UpdatedAtColumn, EmailColumn, PhoneNumberColumn, NameColumn, PasswordColumn, AvatarColumn, BirthDateColumn, BioColumn, ActiveColumn}
 	)
 
 	return userTable{
 		Table: postgres.NewTable(schemaName, tableName, alias, allColumns...),
 
 		//Columns
-		ID:           IDColumn,
-		CreatedAt:    CreatedAtColumn,
-		UpdatedAt:    UpdatedAtColumn,
-		Email:        EmailColumn,
-		PhoneNumber:  PhoneNumberColumn,
-		Name:         NameColumn,
-		Password:     PasswordColumn,
-		Avatar:       AvatarColumn,
-		BirthDate:    BirthDateColumn,
-		Bio:          BioColumn,
-		Active:       ActiveColumn,
-		AuthPlatform: AuthPlatformColumn,
+		ID:          IDColumn,
+		CreatedAt:   CreatedAtColumn,
+		UpdatedAt:   UpdatedAtColumn,
+		Email:       EmailColumn,
+		PhoneNumber: PhoneNumberColumn,
+		Name:        NameColumn,
+		Password:    PasswordColumn,
+		Avatar:      AvatarColumn,
+		BirthDate:   BirthDateColumn,
+		Bio:         BioColumn,
+		Active:      ActiveColumn,
 
 		AllColumns:     allColumns,
 		MutableColumns: mutableColumns,

--- a/database/migrations/1713813908682984_auth_platform_column.sql
+++ b/database/migrations/1713813908682984_auth_platform_column.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "user"
+DROP COLUMN "auth_platform";
+
+ALTER TABLE "auth_state"
+ADD COLUMN "platform" "user_auth_platform_type" NOT NULL DEFAULT 'INTERNAL';

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -7868,14 +7868,11 @@ func (ec *executionContext) _User_authPlatform(ctx context.Context, field graphq
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(gmodel.AuthPlatformType)
+	res := resTmp.(*gmodel.AuthPlatformType)
 	fc.Result = res
-	return ec.marshalNAuthPlatformType2githubᚗcomᚋstadioᚑappᚋstadioᚑbackendᚋgraphᚋgmodelᚐAuthPlatformType(ctx, field.Selections, res)
+	return ec.marshalOAuthPlatformType2ᚖgithubᚗcomᚋstadioᚑappᚋstadioᚑbackendᚋgraphᚋgmodelᚐAuthPlatformType(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_User_authPlatform(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -11421,9 +11418,6 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			}
 		case "authPlatform":
 			out.Values[i] = ec._User_authPlatform(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		case "authStateId":
 			out.Values[i] = ec._User_authStateId(ctx, field, obj)
 		default:
@@ -11894,16 +11888,6 @@ func (ec *executionContext) marshalNAuth2ᚖgithubᚗcomᚋstadioᚑappᚋstadio
 		return graphql.Null
 	}
 	return ec._Auth(ctx, sel, v)
-}
-
-func (ec *executionContext) unmarshalNAuthPlatformType2githubᚗcomᚋstadioᚑappᚋstadioᚑbackendᚋgraphᚋgmodelᚐAuthPlatformType(ctx context.Context, v interface{}) (gmodel.AuthPlatformType, error) {
-	var res gmodel.AuthPlatformType
-	err := res.UnmarshalGQL(v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNAuthPlatformType2githubᚗcomᚋstadioᚑappᚋstadioᚑbackendᚋgraphᚋgmodelᚐAuthPlatformType(ctx context.Context, sel ast.SelectionSet, v gmodel.AuthPlatformType) graphql.Marshaler {
-	return v
 }
 
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interface{}) (bool, error) {
@@ -12586,6 +12570,22 @@ func (ec *executionContext) marshalOAddress2ᚖgithubᚗcomᚋstadioᚑappᚋsta
 		return graphql.Null
 	}
 	return ec._Address(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOAuthPlatformType2ᚖgithubᚗcomᚋstadioᚑappᚋstadioᚑbackendᚋgraphᚋgmodelᚐAuthPlatformType(ctx context.Context, v interface{}) (*gmodel.AuthPlatformType, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(gmodel.AuthPlatformType)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOAuthPlatformType2ᚖgithubᚗcomᚋstadioᚑappᚋstadioᚑbackendᚋgraphᚋgmodelᚐAuthPlatformType(ctx context.Context, sel ast.SelectionSet, v *gmodel.AuthPlatformType) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
 }
 
 func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interface{}) (bool, error) {

--- a/graph/gmodel/models_gen.go
+++ b/graph/gmodel/models_gen.go
@@ -219,18 +219,18 @@ type UpdatedByUser struct {
 }
 
 type User struct {
-	ID           int64            `json:"id" sql:"primary_key"`
-	CreatedAt    time.Time        `json:"createdAt"`
-	UpdatedAt    time.Time        `json:"updatedAt"`
-	Email        string           `json:"email"`
-	PhoneNumber  *string          `json:"phoneNumber,omitempty"`
-	Name         string           `json:"name"`
-	Avatar       *string          `json:"avatar,omitempty"`
-	BirthDate    *time.Time       `json:"birthDate,omitempty"`
-	Bio          *string          `json:"bio,omitempty"`
-	Active       bool             `json:"active"`
-	AuthPlatform AuthPlatformType `json:"authPlatform"`
-	AuthStateID  *int64           `json:"authStateId,omitempty" alias:"auth_state.id"`
+	ID           int64             `json:"id" sql:"primary_key"`
+	CreatedAt    time.Time         `json:"createdAt"`
+	UpdatedAt    time.Time         `json:"updatedAt"`
+	Email        string            `json:"email"`
+	PhoneNumber  *string           `json:"phoneNumber,omitempty"`
+	Name         string            `json:"name"`
+	Avatar       *string           `json:"avatar,omitempty"`
+	BirthDate    *time.Time        `json:"birthDate,omitempty"`
+	Bio          *string           `json:"bio,omitempty"`
+	Active       bool              `json:"active"`
+	AuthPlatform *AuthPlatformType `json:"authPlatform,omitempty" alias:"auth_state.platform"`
+	AuthStateID  *int64            `json:"authStateId,omitempty" alias:"auth_state.id"`
 }
 
 type UserShallow struct {

--- a/graph/resolver/user.resolvers.go
+++ b/graph/resolver/user.resolvers.go
@@ -51,13 +51,13 @@ func (r *mutationResolver) ResendEmailVerificationCode(ctx context.Context, emai
 
 // Login is the resolver for the login field.
 func (r *queryResolver) Login(ctx context.Context, email string, password string) (*gmodel.Auth, error) {
-	auth, err := r.Service.LoginInternal(ctx, email, password)
+	auth, err := r.Service.LoginInternal(ctx, email, password, nil)
 	return &auth, err
 }
 
 // GoogleOAuth is the resolver for the googleOAuth field.
 func (r *queryResolver) GoogleOAuth(ctx context.Context, accessToken string) (*gmodel.Auth, error) {
-	auth, err := r.Service.GoogleAuthentication(ctx, accessToken)
+	auth, err := r.Service.GoogleAuthentication(ctx, accessToken, nil)
 	return &auth, err
 }
 

--- a/graph/user.graphql
+++ b/graph/user.graphql
@@ -34,7 +34,7 @@ type User {
   birthDate: Time
   bio: String
   active: Boolean!
-  authPlatform: AuthPlatformType!
+  authPlatform: AuthPlatformType @goTag(key: "alias", value: "auth_state.platform")
   authStateId: ID @goTag(key: "alias", value: "auth_state.id")
 }
 

--- a/services/auth_service.go
+++ b/services/auth_service.go
@@ -163,8 +163,8 @@ func (Service) GenerateJWT(key string, user *gmodel.User) (string, error) {
 		"id": user.ID,
 		"name": user.Name,
 		"email": user.Email,
-		"authPlatform": user.AuthPlatform.String(),
-		"authStateId": user.AuthStateID,
+		"authPlatform": (*user.AuthPlatform).String(),
+		"authStateId": *user.AuthStateID,
 		"iat": time.Now().Unix(),
 		"exp": time.Now().Add(time.Hour * 24 * 30).Unix(),
 	})
@@ -196,6 +196,7 @@ func (service Service) VerifyJwt(ctx context.Context, authorization types.Author
 		SELECT(
 			table.User.AllColumns,
 			table.AuthState.ID,
+			table.AuthState.Platform,
 		).
 		FROM(table.User.LEFT_JOIN(
 			table.AuthState, 

--- a/services/auth_service.go
+++ b/services/auth_service.go
@@ -18,13 +18,15 @@ import (
 const EMAIL_VERIFICATION_CODE_LEN = 10
 
 // Given an existing user, create an auth_state row
-func (service Service) CreateAuthState(ctx context.Context, user gmodel.User, ip_address *string) (model.AuthState, error) {
+func (service Service) CreateAuthState(ctx context.Context, user gmodel.User, auth_platform model.UserAuthPlatformType, ip_address *string) (model.AuthState, error) {
 	query := table.AuthState.INSERT(
 		table.AuthState.UserID,
 		table.AuthState.IPAddress,
+		table.AuthState.Platform,
 	).MODEL(model.AuthState{
 		UserID: user.ID,
 		IPAddress: ip_address,
+		Platform: auth_platform,
 	}).RETURNING(table.AuthState.AllColumns)
 
 	var auth_state model.AuthState

--- a/services/user_service.go
+++ b/services/user_service.go
@@ -151,7 +151,11 @@ func (service Service) CreateAuthStateWithJwt(
 	}
 
 	qb := table.User.
-		SELECT(table.User.AllColumns, table.AuthState.ID).
+		SELECT(
+			table.User.AllColumns,
+			table.AuthState.ID, 
+			table.AuthState.Platform,
+		).
 		FROM(table.User.LEFT_JOIN(
 			table.AuthState, 
 			table.User.ID.EQ(table.AuthState.UserID),

--- a/services/user_service.go
+++ b/services/user_service.go
@@ -33,7 +33,6 @@ func (service Service) CreateInternalUser(ctx context.Context, input gmodel.Crea
 			table.User.Email,
 			table.User.Name,
 			table.User.Password,
-			table.User.AuthPlatform,
 			table.User.Active,
 			table.User.PhoneNumber,
 		).
@@ -41,7 +40,6 @@ func (service Service) CreateInternalUser(ctx context.Context, input gmodel.Crea
 			Email: input.Email,
 			Name: input.Name,
 			Password: &hashed_password,
-			AuthPlatform: model.UserAuthPlatformType_Internal,
 			Active: false,
 			PhoneNumber: input.PhoneNumber,
 		}).
@@ -70,14 +68,12 @@ func (service Service) CreateOauthUser(ctx context.Context, input gmodel.CreateA
 		INSERT(
 			table.User.Email,
 			table.User.Name,
-			table.User.AuthPlatform,
 			table.User.Active,
 			table.User.PhoneNumber,
 		).
 		MODEL(model.User{
 			Email: input.Email,
 			Name: input.Name,
-			AuthPlatform: oauth_type,
 			Active: true,
 			PhoneNumber: input.PhoneNumber,
 		}).
@@ -88,7 +84,7 @@ func (service Service) CreateOauthUser(ctx context.Context, input gmodel.CreateA
 	return user, nil
 }
 
-func (service Service) GoogleAuthentication(ctx context.Context, access_token string) (gmodel.Auth, error) {
+func (service Service) GoogleAuthentication(ctx context.Context, access_token string, ip_address *string) (gmodel.Auth, error) {
 	oauth_service, err := oauth2.NewService(ctx, option.WithoutAuthentication())
 	if err != nil {
 		return gmodel.Auth{}, fmt.Errorf("could not create service")
@@ -113,14 +109,14 @@ func (service Service) GoogleAuthentication(ctx context.Context, access_token st
 		}
 		new_user = true
 	}
-	auth_state, err := service.CreateAuthStateWithJwt(ctx, user.ID)
+	auth_state, err := service.CreateAuthStateWithJwt(ctx, user.ID, model.UserAuthPlatformType_Google, ip_address)
 	if err == nil && new_user {
 		auth_state.IsNewUser = &new_user
 	}
 	return auth_state, err
 }
 
-func (service Service) LoginInternal(ctx context.Context, email string, password string) (gmodel.Auth, error) {
+func (service Service) LoginInternal(ctx context.Context, email string, password string, ip_address *string) (gmodel.Auth, error) {
 	db := service.DbOrTxQueryable()	
 	query := table.User.
 		SELECT(table.User.AllColumns).
@@ -140,13 +136,16 @@ func (service Service) LoginInternal(ctx context.Context, email string, password
 		return gmodel.Auth{}, fmt.Errorf("incorrect email or password")
 	}
 
-	return service.CreateAuthStateWithJwt(ctx, verify_user.ID)
+	return service.CreateAuthStateWithJwt(ctx, verify_user.ID, model.UserAuthPlatformType_Internal, ip_address)
 }
 
-func (service Service) CreateAuthStateWithJwt(ctx context.Context, user_id int64) (gmodel.Auth, error) {
-	auth_state, auth_state_err := service.CreateAuthState(ctx, gmodel.User{
-		ID: user_id,
-	}, nil)
+func (service Service) CreateAuthStateWithJwt(
+	ctx context.Context, 
+	user_id int64, 
+	auth_platform model.UserAuthPlatformType, 
+	ip_address *string,
+) (gmodel.Auth, error) {
+	auth_state, auth_state_err := service.CreateAuthState(ctx, gmodel.User{ ID: user_id }, auth_platform, ip_address)
 	if auth_state_err != nil {
 		return gmodel.Auth{}, fmt.Errorf("could not create auth state")
 	}

--- a/tests/user_test.go
+++ b/tests/user_test.go
@@ -32,9 +32,6 @@ func TestUser(t *testing.T) {
 		if user1.Active {
 			t.Fatal("User.Active should be set to false")
 		}
-		if user1.AuthPlatform != gmodel.AuthPlatformTypeInternal {
-			t.Fatal("user auth platform should be internal")
-		}
 
 		t.Parallel()
 
@@ -132,6 +129,7 @@ func TestUser(t *testing.T) {
 					t.Fatal("could not login", err.Error())
 				}
 				user1.AuthStateID = user1_auth.User.AuthStateID
+				user1.AuthPlatform = user1_auth.User.AuthPlatform
 				if *user1_auth.User != user1 {
 					t.Fatal("returned user object does not match")
 				}

--- a/tests/user_test.go
+++ b/tests/user_test.go
@@ -109,7 +109,7 @@ func TestUser(t *testing.T) {
 	t.Run("login", func(t *testing.T) {
 		t.Run("correct input", func(t *testing.T) {
 			t.Run("inactive user", func(t *testing.T) {
-				_, err := service.LoginInternal(ctx, user1_input.Email, user1_input.Password)
+				_, err := service.LoginInternal(ctx, user1_input.Email, user1_input.Password, nil)
 				if err == nil {
 					t.Fatal("should not login. user is still inactive")
 				}
@@ -127,7 +127,7 @@ func TestUser(t *testing.T) {
 				}
 				user1.Active = true
 
-				user1_auth, err = service.LoginInternal(ctx, user1_input.Email, user1_input.Password)
+				user1_auth, err = service.LoginInternal(ctx, user1_input.Email, user1_input.Password, nil)
 				if err != nil {
 					t.Fatal("could not login", err.Error())
 				}
@@ -169,7 +169,7 @@ func TestUser(t *testing.T) {
 				})
 
 				t.Run("new login should create new auth_state entry", func(t *testing.T) {
-					user1_auth2, err = service.LoginInternal(ctx, user1_input.Email, user1_input.Password)
+					user1_auth2, err = service.LoginInternal(ctx, user1_input.Email, user1_input.Password, nil)
 					if err != nil {
 						t.Fatal("could not login", err.Error())
 					}
@@ -192,7 +192,7 @@ func TestUser(t *testing.T) {
 		})
 
 		t.Run("incorrect input", func(t *testing.T) {
-			_, err := service.LoginInternal(ctx, user1_input.Email, "somerandompassword")
+			_, err := service.LoginInternal(ctx, user1_input.Email, "somerandompassword", nil)
 			if err == nil {
 				t.Fatal("login should fail. password is incorrect")
 			}


### PR DESCRIPTION
This PR replaces the `user.auth_platform` column with the same column (type, constraints, etc.) inside `auth_state`. This will allow us to know the login platform used for each login state. This will also be useful when looking for insecure logins.